### PR TITLE
Add citation page in Swedish

### DIFF
--- a/content/english/citation.md
+++ b/content/english/citation.md
@@ -33,9 +33,9 @@ For official guidance see the [SciCrunch page on RRID citations](https://scicrun
 
 **In-text citation**: Swedish Pathogens Portal, SciLifeLab Data Centre, _version number_, RRID: SCR_024866. (Access date: date of access).
 
-**Reference list**: Swedish Pathogens Portal (_access date_), SciLifeLab Data Centre, version (version number) from https://pathogens.se, RRID:SCR_024866.
+**Reference list**: Swedish Pathogens Portal (_access date_), SciLifeLab Data Centre, version (version number) from https://www.pathogens.se, RRID:SCR_024866.
 
-You will find the version number of the portal at the bottom of the footer on any page, or on our <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">Github repository</a> under 'releases'.
+You will find the version number of the portal at the bottom of the footer on any page, or on our <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">pathogens-portal GitHub repository</a> under 'releases'.
 
 If you are aiming to cite particular pages of the portal in particular (e.g. the Data Highlights), you may find that an author is mentioned and a date is given. In this case, you should include the appropriate date and author instead, but must still include the RRID. There are also some pages were information for how to cite the data itself is provided (e.g. where a DOI is given on a dashboard page). In those cases, you should use that citation.
 
@@ -51,4 +51,4 @@ SciLifeLab Data Centre (year) pathogens-portal-visualisations. version: (version
 
 ## Journalists
 
-Journalists are welcome to reuse images, content, or other material from the **Swedish Pathogens Portal** for articles, blogs, social media etc., provided that the portal is acknowledged. Please refer to the portal as the **Swedish Pathogens Portal** and link to our webpage <https://pathogens.se> when you use content from the portal. You may also include our RRID: **SCR_024866** (see above for information on RRIDs).
+Journalists are welcome to reuse images, content, or other material from the **Swedish Pathogens Portal** for articles, blogs, social media etc., provided that the portal is acknowledged. Please refer to the portal as the **Swedish Pathogens Portal** and link to our webpage <https://www.pathogens.se> when you use content from the portal. You may also include our RRID: **SCR_024866** (see above for information on RRIDs).

--- a/content/svenska/citation.md
+++ b/content/svenska/citation.md
@@ -11,7 +11,7 @@ menu:
 toc: true
 ---
 
-I linje med principerna för öppen vetenskap och FAIR är data, information och resurser från Pathogens Portal Sverige fritt tillgängligt för användning och återanvändning. På den här sidan hittar du information om hur du på ett korrekt sätt kan citera när du återanvänder eller refererar till innehåll på portalen. Observera att informationen på portalen uppdateras kontinuerligt, därför är det viktigt att hänvisa till specifik version (eller ange åtkomstdatum) vid citering.
+I linje med principerna för öppen vetenskap och FAIR är data, information, och resurser från Pathogens Portal Sverige fritt tillgängligt för användning och återanvändning. På den här sidan hittar du information om hur du på ett korrekt sätt kan citera när du återanvänder eller refererar till innehåll på portalen. Observera att informationen på portalen uppdateras kontinuerligt, därför är det viktigt att hänvisa till specifik version (eller ange åtkomstdatum) vid citering.
 
 ## För forskare
 
@@ -21,7 +21,7 @@ I det här avsnittet finner du instruktioner för hur du kan citera portalwebbpl
 
 ##### Research Resource Identifier för Pathogens Portal Sverige
 
-The Resource Identification Portal skapades till stöd för <a target="_blank" href="https://www.rrids.org/">Resource Identification Initiative</a>. Det syftar till att främja identifiering, upptäckt och återanvändning av forskningsresurser. Research Resource Identifiers (RRIDs) är persistenta och unika identifierare som används för att referera forskningsresurser.
+The Resource Identification Portal skapades till stöd för <a target="_blank" href="https://www.rrids.org/">Resource Identification Initiative</a>. Det syftar till att främja identifiering, upptäckt och återanvändning av forskningsresurser. Research Resource Identifiers (**RRIDs**) är persistenta och unika identifierare som används för att referera forskningsresurser.
 
 RRID för Pathogens Portal Sverige är [**SCR_024866**](https://scicrunch.org/resources/data/record/nlx_144509-1/SCR_024866/resolver?q=SCR_024866&l=SCR_024866&i=rrid:scr_024866).
 
@@ -31,17 +31,17 @@ Att lägga till portalens RRID vid citering bidrar till att öka återanvändnin
 
 För officiell vägledning se [SciCrunch-sidan om RRID-citat](https://scicrunch.org/resources/about/guidelines).
 
-**Hänvisning i text:**: Swedish Pathogens Portal, SciLifeLab Data Centre, _version number_, RRID: SCR_024866. (Access date: date of access).
+**Hänvisning i text:** Swedish Pathogens Portal, SciLifeLab Data Centre, _versionsnummer_, RRID: SCR_024866. (nedladdningsdatum).
 
-**Reference list**: Swedish Pathogens Portal (_access date_), SciLifeLab Data Centre, version (version number) from https://pathogens.se, RRID:SCR_024866.
+**Reference list**: Swedish Pathogens Portal (_nedladdningsdatum_), SciLifeLab Data Centre, version (versionsnummer) from https://www.pathogens.se, RRID:SCR_024866.
 
-Du hittar versionsnumret på portalen längst ner I sidfoten på valfri sida, eller på vårt <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">Github repositorie</a> under 'releases'.
+Du hittar versionsnumret på portalen längst ner i sidfoten på valfri sida, eller på vårt <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">pathogens-portal repository</a> under 'releases'.
 
-Om du vill citera en särskild sida från portalen som exempelvis "Data Highlights", kan du i vissa fall se att denna sida har en egen författare och publiceringsdatum. I detta fall bör du inkludera datum och författare, men samtidigt lägga till RRID. Det finns också vissa sidor där information om hur man kan citera data tillhandahålls, exempelvis separata doi för vissa dashboards som du bör använda för citering.
+Om du vill citera en särskild sida från portalen som exempelvis "Data Highlights", kan du i vissa fall se att denna sida har en egen författare och publiceringsdatum. I detta fall bör du inkludera datum och författare, men samtidigt lägga till RRID. Det finns också vissa sidor där information om hur man kan citera data tillhandahålls, exempelvis separata DOI för vissa dashboards som du bör använda för citering.
 
 ### Citera källkod
 
-Portalens källkod har skapats av <a target="_blank" href="https://scilifelab.se/data">SciLifeLab Data Centre</a> ch samarbetspartners. Många forskare från forskarsamhället har även bidragit till att utveckla källkoden. Portalens källkod ligger öppet tillgänglig för återanvändning på GitHub. Källkod för webbsidan ligger i <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">pathogens-portal repository</a>, och all källkod för visualiseringar ligger i  <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations">visualisations repository</a>. All källkod görs tillgänglig för återanvändning under en MIT licens.
+Portalens källkod har skapats av <a target="_blank" href="https://scilifelab.se/data">SciLifeLab Data Centre</a> och samarbetspartners. Många forskare från forskarsamhället har även bidragit till att utveckla källkoden. Portalens källkod ligger öppet tillgänglig för återanvändning på GitHub. Källkod för webbsidan ligger i <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">pathogens-portal repository</a>, och all källkod för visualiseringar ligger i <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations">pathogens-portal-visualisations repository</a>. All källkod görs tillgänglig för återanvändning under en MIT licens.
 
 ##### APA format
 
@@ -49,8 +49,8 @@ SciLifeLab Data Centre (år) pathogens-portal. version: (versionsnummer)[Program
 Zenodo. <https://zenodo.org/doi/10.5281/zenodo.10629602>.
 
 SciLifeLab Data Centre (år) pathogens-portal-visualiseringar. version:
-(versionsnummer)[Programvara]. Zenodo. _DOI to be confirmed_.
+(versionsnummer)[Programvara]. Zenodo. _DOI saknas_.
 
 ## Journalister
 
-Journalister är välkomna att återanvänd bilder, innehåll och annat material på **Pathogens Portal Sverige** för exempelvis artiklar, bloggar och sociala media poster under förutsättning att portalen anges som käll. Vänligen ange **Pathogens Portal Sverige** och länka till webbsidan <https://pathogens.se> när du använder material från portalen. Om möjligt inkludera även RRID: **SCR_024866** (se information ovan kring RRID nummer).
+Journalister är välkomna att återanvänd bilder, innehåll och annat material på **Pathogens Portal Sverige** för exempelvis artiklar, bloggar och sociala media poster under förutsättning att portalen anges som käll. Vänligen ange **Pathogens Portal Sverige** och länka till webbsidan <https://www.pathogens.se> när du använder material från portalen. Om möjligt inkludera även RRID: **SCR_024866** (se information ovan kring RRID nummer).

--- a/content/svenska/citation.md
+++ b/content/svenska/citation.md
@@ -1,0 +1,56 @@
+---
+title: Citera data, information och resurser från portalen
+menu:
+  top_actions:
+    name: Citera oss
+    weight: 80
+    pre: <i class="bi bi-patch-exclamation-fill me-2"></i>
+  footer_about:
+    name: Citera oss
+    weight: 30
+toc: true
+---
+
+I linje med principerna för öppen vetenskap och FAIR är data, information och resurser från Pathogens Portal Sverige fritt tillgängligt för användning och återanvändning. På den här sidan hittar du information om hur du på ett korrekt sätt kan citera när du återanvänder eller refererar till innehåll på portalen. Observera att informationen på portalen uppdateras kontinuerligt, därför är det viktigt att hänvisa till specifik version (eller ange åtkomstdatum) vid citering.
+
+## För forskare
+
+I det här avsnittet finner du instruktioner för hur du kan citera portalwebbplatsen, eller underliggande källkod, i forskningspublikationer.
+
+### Citera webbplatsens innehåll
+
+##### Research Resource Identifier för Pathogens Portal Sverige
+
+The Resource Identification Portal skapades till stöd för <a target="_blank" href="https://www.rrids.org/">Resource Identification Initiative</a>. Det syftar till att främja identifiering, upptäckt och återanvändning av forskningsresurser. Research Resource Identifiers (RRIDs) är persistenta och unika identifierare som används för att referera forskningsresurser.
+
+RRID för Pathogens Portal Sverige är [**SCR_024866**](https://scicrunch.org/resources/data/record/nlx_144509-1/SCR_024866/resolver?q=SCR_024866&l=SCR_024866&i=rrid:scr_024866).
+
+Att lägga till portalens RRID vid citering bidrar till att öka återanvändning av data, information och resurser från portalen, och gör det möjligt för oss att spåra aktivitet samt och tillåta andra att enkelt hitta den sammanfattande rapporten för användning av Pathogens Portal Sverige.
+
+##### APA format
+
+För officiell vägledning se [SciCrunch-sidan om RRID-citat](https://scicrunch.org/resources/about/guidelines).
+
+**Hänvisning i text:**: Swedish Pathogens Portal, SciLifeLab Data Centre, _version number_, RRID: SCR_024866. (Access date: date of access).
+
+**Reference list**: Swedish Pathogens Portal (_access date_), SciLifeLab Data Centre, version (version number) from https://pathogens.se, RRID:SCR_024866.
+
+Du hittar versionsnumret på portalen längst ner I sidfoten på valfri sida, eller på vårt <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">Github repositorie</a> under 'releases'.
+
+Om du vill citera en särskild sida från portalen som exempelvis "Data Highlights", kan du i vissa fall se att denna sida har en egen författare och publiceringsdatum. I detta fall bör du inkludera datum och författare, men samtidigt lägga till RRID. Det finns också vissa sidor där information om hur man kan citera data tillhandahålls, exempelvis separata doi för vissa dashboards som du bör använda för citering.
+
+### Citera källkod
+
+Portalens källkod har skapats av <a target="_blank" href="https://scilifelab.se/data">SciLifeLab Data Centre</a> ch samarbetspartners. Många forskare från forskarsamhället har även bidragit till att utveckla källkoden. Portalens källkod ligger öppet tillgänglig för återanvändning på GitHub. Källkod för webbsidan ligger i <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal">pathogens-portal repository</a>, och all källkod för visualiseringar ligger i  <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations">visualisations repository</a>. All källkod görs tillgänglig för återanvändning under en MIT licens.
+
+##### APA format
+
+SciLifeLab Data Centre (år) pathogens-portal. version: (versionsnummer)[Programvara].
+Zenodo. <https://zenodo.org/doi/10.5281/zenodo.10629602>.
+
+SciLifeLab Data Centre (år) pathogens-portal-visualiseringar. version:
+(versionsnummer)[Programvara]. Zenodo. _DOI to be confirmed_.
+
+## Journalister
+
+Journalister är välkomna att återanvänd bilder, innehåll och annat material på **Pathogens Portal Sverige** för exempelvis artiklar, bloggar och sociala media poster under förutsättning att portalen anges som käll. Vänligen ange **Pathogens Portal Sverige** och länka till webbsidan <https://pathogens.se> när du använder material från portalen. Om möjligt inkludera även RRID: **SCR_024866** (se information ovan kring RRID nummer).


### PR DESCRIPTION
In this contribution, I've implemented a 'cite us Swedish' page to provide users with guidelines and resources for citing our work in Swedish publications. This addition enhances the accessibility and clarity of our documentation, catering specifically to Swedish-speaking audiences and facilitating proper citation practices within that context.