### PR TITLE
Add all to dashboard and topics menu

### DIFF
--- a/content/english/dashboards/_index.md
+++ b/content/english/dashboards/_index.md
@@ -9,7 +9,7 @@ menu:
         post: Dashboards are pages describing research done on a given subject. They include visualisations of and links to data from the research groups(s) involved. <a href="/dashboards/">See all dashboards <i class="bi bi-arrow-right-circle-fill"></i></a>
     dashboard_menu:
         identifier: all_dashboards
-        name: "All dasboards"
+        name: "All dashboards"
         weight: 1
 aliases:
       - /dashboards

--- a/content/english/dashboards/_index.md
+++ b/content/english/dashboards/_index.md
@@ -7,6 +7,10 @@ menu:
         name: Dashboards
         identifier: dashboards
         post: Dashboards are pages describing research done on a given subject. They include visualisations of and links to data from the research groups(s) involved. <a href="/dashboards/">See all dashboards <i class="bi bi-arrow-right-circle-fill"></i></a>
+    dashboard_menu:
+        identifier: all_dashboards
+        name: "All dasboards"
+        weight: 1
 aliases:
       - /dashboards
       - /visualisations

--- a/content/english/topics/_index.md
+++ b/content/english/topics/_index.md
@@ -1,0 +1,8 @@
+---
+title: Topics
+menu:
+    topics_menu:
+        name: All topics
+        identifier: all_topics
+        weight: 1
+---

--- a/content/svenska/dashboards/_index.md
+++ b/content/svenska/dashboards/_index.md
@@ -9,6 +9,6 @@ menu:
         post: Visualiseringar av datasets samt en översikt över pågående forskning kring en viss fråga. <a href="/sv/dashboards/">Se alla dashboards <i class="bi bi-arrow-right-circle-fill"></i></a>
     dashboard_menu:
         identifier: all_dashboards
-        name: "Alla dasboards"
+        name: "Alla dashboards"
         weight: 1
 ---

--- a/content/svenska/dashboards/_index.md
+++ b/content/svenska/dashboards/_index.md
@@ -7,4 +7,8 @@ menu:
         name: Dashboards
         identifier: dashboards
         post: Visualiseringar av datasets samt en översikt över pågående forskning kring en viss fråga. <a href="/sv/dashboards/">Se alla dashboards <i class="bi bi-arrow-right-circle-fill"></i></a>
+    dashboard_menu:
+        identifier: all_dashboards
+        name: "Alla dasboards"
+        weight: 1
 ---

--- a/layouts/partials/dashboards.html
+++ b/layouts/partials/dashboards.html
@@ -6,7 +6,7 @@
 
 {{/* Compile list of highlight to show depending upon the page */}}
 {{ if eq $currentPage.File "dashboards" }}
-  {{ $dashboards_to_show = $dashboards_to_show | append $dashboards }}
+  {{ $dashboards_to_show = $dashboards_to_show | append (where $dashboards "Identifier" "ne" "all_dashboards") }}
 {{ else if $displayed_in_homepage }}
   {{ $dashboards_to_show = $dashboards_to_show | append (where $dashboards "Identifier" "in" $homepage_dashboards) }}
 {{ else if strings.HasSuffix $currentPage.Dir "/topics/" }}

--- a/layouts/partials/topics.html
+++ b/layouts/partials/topics.html
@@ -1,5 +1,5 @@
 <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-2 g-lg-3">
-  {{ range .Site.Menus.topics_menu }}
+  {{ range where .Site.Menus.topics_menu "Identifier" "ne" "all_topics"}}
       <div class="col">
         <div class="bg-card">
           <figure class="figure">


### PR DESCRIPTION
In the top navigation bar, add "All dashboards" and "All topics" as sub entry in their respective menu for easy access.

`weight: 1` is specified so it always stays on the top