### PR TITLE
Pass `HUGO_ENV_ARG` to Hugo build in Dockerfile

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -2,15 +2,16 @@
 FROM alpine:3.19.1 AS build
 RUN apk add --no-cache wget=1.21.4-r0
 ARG HUGO_VERSION="0.123.7"
+ARG HUGO_ENV_ARG
+WORKDIR /src
+COPY ./ /src
 RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" && \
     tar xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     rm -r hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     mv hugo /usr/bin && \
     chmod 755 /usr/bin/hugo
-WORKDIR /src
-COPY ./ /src
-RUN mkdir /target && \
-    hugo -d /target
+    mkdir /target && \
+    hugo -d /target -e "${HUGO_ENV_ARG}"
 
 # Serve the generated html using nginx
 FROM nginxinc/nginx-unprivileged:alpine


### PR DESCRIPTION
This aims to pass the build commit hash to Hugo so we can retrieve it and display it in the template footer.