### PR TITLE
Minor fix for multi-word topics

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -182,7 +182,7 @@
     <div class="bg-home-topics mb-4">
       <h4 class="mt-0 mb-1">Pandemic preparedness topics</h4>
       <p class="mb-2 small">Click on one of the <b><a class="dark-blue" href="/topics/">topics</a></b> below to see only the content that is related to that topic.</p>
-      {{ range .Site.Menus.topics_menu }}
+      {{ range where .Site.Menus.topics_menu "Identifier" "ne" "all_topics" }}
         <a href="{{ .Page.RelPermalink }}"><span class="bg-home-topics-btn">{{ .Name }}</span></a>
       {{ end }}
     </div>

--- a/layouts/topics/single.html
+++ b/layouts/topics/single.html
@@ -1,7 +1,8 @@
 {{ define "main" }}
 
 {{ $page_topic := .Page.Params.topic }}
-{{ $topic_key := $page_topic | urlize }}
+{{ $topic_key := $page_topic | lower }}
+{{ $topic_key_url := $page_topic | urlize }}
 
 <!-- Content from the markdown file -->
 {{ .Content }}
@@ -13,7 +14,7 @@
 <div class="container mt-3 mb-5">
   {{- partial "highlights.html" . -}}
   <div class="mt-2 fw-bold align-content-end">
-    <a href="/highlights/topics/{{ $topic_key }}">See all data highlights on {{ $page_topic }} ({{ $n_dh }}) 
+    <a href="/highlights/topics/{{ $topic_key_url }}">See all data highlights on {{ $page_topic }} ({{ $n_dh }}) 
       <i class="bi bi-arrow-right-circle-fill"></i>
     </a>
   </div>
@@ -27,7 +28,7 @@
 <h3><i class="bi bi-three-dots-vertical"></i> Dashboards ({{ $n_db }})</h3>
 <div class="container mt-3 mb-5">
   {{- partial "dashboards.html" . -}}
-  <div class="mt-2 fw-bold align-content-end"><a href="/dashboards/topics/{{ $topic_key }}">See all dashboards
+  <div class="mt-2 fw-bold align-content-end"><a href="/dashboards/topics/{{ $topic_key_url }}">See all dashboards
     on {{ $page_topic }} ({{ $n_db }}) <i class="bi bi-arrow-right-circle-fill"></i></a></div>
 <hr>
 </div>
@@ -39,7 +40,7 @@
 <h3><i class="bi bi-three-dots-vertical"></i> Editorials ({{ $n_ed }})</h3>
 <div class="container mt-3 mb-5">
   {{- partial "editorials.html" . -}}
-  <div class="mt-2 fw-bold align-content-end"><a href="/editorials/topics/{{ $topic_key }}">See all editorials
+  <div class="mt-2 fw-bold align-content-end"><a href="/editorials/topics/{{ $topic_key_url }}">See all editorials
     on {{ $page_topic }} ({{ $n_ed }}) <i class="bi bi-arrow-right-circle-fill"></i></a></div>
 <hr>
 </div>


### PR DESCRIPTION
Currently it uses "url" format to retrieve the relevant content for each topic, this dint work well for multi worded tags.

Example, for `infectious diseases` topics, it used `infectious-diseases` to retrieve the contents.

This PR fixes it, so the right format is used to retrieve the contents.