### PR TITLE
FREYA-891 :: Modify script in layouts/partials/dashboards.html

### DIFF
--- a/layouts/partials/dashboards.html
+++ b/layouts/partials/dashboards.html
@@ -167,11 +167,14 @@
                  month: 'short',
                  day: 'numeric'
              });
-
              cardData.push({ card, updatedDate });
 
          } else {
-             spanElement.textContent = 'No matching entry in EBI index';
+             // In case there is no entry in the EBI file yet,
+             // we add a mock date for the reordering to keep working
+             spanElement.textContent = 'not yet available';
+             updatedDate = new Date('1900-01-01');
+             cardData.push({ card, updatedDate });
          }
      });
 


### PR DESCRIPTION
This enables dashboard cards to show up even if there is no matching entry in the EBI index file yet.
These cards will be at the bottom of the dashboard grid and display a text indicating the absence of entry in EBI index.