### PR TITLE
Fix accessibility reported by pa11y

### DIFF
--- a/content/english/dashboards/RECOVAC.md
+++ b/content/english/dashboards/RECOVAC.md
@@ -56,7 +56,7 @@ In order to infer the impact of vaccination on ICU admissions, it is best to dir
 
 The graphs below have multiple interactive features. In brief, it is possible to view different parts of the data using the buttons above the graphs. For exmaple, it is possible to look only at data from only those over 60 years of age by clicking '>60'. The 'Align timeline' button will change the timeline of the graphs so that only period for which data is available for both types of data shown is visible. The 'Show all data' button can be used to see all of the available data for both datasets (the timelines of the two are not the same).
 
-<div id="dwbuttons"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_one" aria-expanded="False" aria-controls="mandatorycollapse">
+<div id="dwbuttonsone"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_one" aria-expanded="False" aria-controls="mandatorycollapse">
     Click here for more detailed instructions on using the features of the graphs
 </button>
 </div>
@@ -112,7 +112,7 @@ There is clear evidence of the benefits of vaccination for patients with each co
 
 The graphs below have multiple interactive features. It is possible to see all of the data available for a given comorbidity for clicking on the corresponding button. The 'Align timeline' button will change the timeframe shown so that only the time period that is common between the two graphs is shown. The 'Show all data' button can be used to see all of the available data for both datasets (the timelines of the two are not the same).
 
-<div id="dwbuttons"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_two" aria-expanded="False" aria-controls="mandatorycollapse">
+<div id="dwbuttonstwo"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_two" aria-expanded="False" aria-controls="mandatorycollapse">
     Click here for more detailed instructions on using the features of the graphs
 </button>
 </div>

--- a/content/english/highlights/immunofluorescence.md
+++ b/content/english/highlights/immunofluorescence.md
@@ -86,7 +86,7 @@ Select a plate to view using the dropdown below. You can see the HPA ID of the a
 <div class="container">
   <div class="row">
     <div class="col-md-3">
-      <select class="form-control" id="select_plate">
+      <select class="form-control" id="select_plate" aria-labelledby="select_plate">
         <option value="p1">Plate 1</option>
         <option value="p2">Plate 2</option>
         <option value="p3">Plate 3</option>

--- a/content/english/privacy.md
+++ b/content/english/privacy.md
@@ -20,7 +20,7 @@ We want to inform you that whenever you visit our **Service**, we collect the in
 
 You can opt out of your Log Data being collected below:
 
-<iframe id="matoOpOut" src="https://matomo.dc.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontSize=16px&fontFamily=Helvetica"></iframe>
+<iframe id="matoOpOut" title="Data share opt out box" src="https://matomo.dc.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontSize=16px&fontFamily=Helvetica"></iframe>
 
 ## Forms
 

--- a/content/svenska/dashboards/RECOVAC.md
+++ b/content/svenska/dashboards/RECOVAC.md
@@ -60,7 +60,7 @@ In order to infer the impact of vaccination on ICU admissions, it is best to dir
 
 The graphs below have multiple interactive features. In brief, it is possible to view different parts of the data using the buttons above the graphs. For exmaple, it is possible to look only at data from only those over 60 years of age by clicking '>60'. The 'Align timeline' button will change the timeline of the graphs so that only period for which data is available for both types of data shown is visible. The 'Show all data' button can be used to see all of the available data for both datasets (the timelines of the two are not the same).
 
-<div id="dwbuttons"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_one" aria-expanded="False" aria-controls="mandatorycollapse">
+<div id="dwbuttonsone"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_one" aria-expanded="False" aria-controls="mandatorycollapse">
     Click here for more detailed instructions on using the features of the graphs
 </button>
 </div>
@@ -116,7 +116,7 @@ There is clear evidence of the benefits of vaccination for patients with each co
 
 The graphs below have multiple interactive features. It is possible to see all of the data available for a given comorbidity for clicking on the corresponding button. The 'Align timeline' button will change the timeframe shown so that only the time period that is common between the two graphs is shown. The 'Show all data' button can be used to see all of the available data for both datasets (the timelines of the two are not the same).
 
-<div id="dwbuttons"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_two" aria-expanded="False" aria-controls="mandatorycollapse">
+<div id="dwbuttonstwo"><button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#vis_instr_two" aria-expanded="False" aria-controls="mandatorycollapse">
     Click here for more detailed instructions on using the features of the graphs
 </button>
 </div>

--- a/content/svenska/privacy.md
+++ b/content/svenska/privacy.md
@@ -21,7 +21,7 @@ Vi vill informera dig om att varje gång du besöker vår **tjänst** samlar vi 
 
 You can opt out of your Log Data being collected below:
 
-<iframe id="matoOpOut" src="https://matomo.dc.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontSize=16px&fontFamily=Helvetica"></iframe>
+<iframe id="matoOpOut" title="Rutan för avanmälan av datadelning" src="https://matomo.dc.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontSize=16px&fontFamily=Helvetica"></iframe>
 
 ## Formulär
 

--- a/layouts/ena_tutorial/single.html
+++ b/layouts/ena_tutorial/single.html
@@ -17,7 +17,7 @@
               {{ .TableOfContents }}
           </aside>
         </div>
-        <div class="col-md-9 order-md-first content" id="content">{{ .Content }}</div>
+        <div class="col-md-9 order-md-first content" id="ena-content">{{ .Content }}</div>
     </div>
 </div>
 

--- a/layouts/shortcodes/crush_covid.html
+++ b/layouts/shortcodes/crush_covid.html
@@ -1,1 +1,1 @@
-<iframe src="https://crush-covid.shinyapps.io/crush_covid/" style="border: none; width: 100%; height: 800px" frameborder="0">The browser is not compatible with this content.</iframe>
+<iframe title="Crush covid app window" src="https://crush-covid.shinyapps.io/crush_covid/" style="border: none; width: 100%; height: 800px" frameborder="0">The browser is not compatible with this content.</iframe>

--- a/layouts/wastewater/list.html
+++ b/layouts/wastewater/list.html
@@ -20,7 +20,7 @@
                 {{ .TableOfContents }}
             </aside>
         </div>
-        <div class="col-md-9 order-md-first content" id="content">{{ .Content }}</div>
+        <div class="col-md-9 order-md-first content" id="into-content">{{ .Content }}</div>
       {{ else }}
         {{ .Content }}
       {{ end }}


### PR DESCRIPTION
These are accessibility issues reported by `pa11y`. These are not raised by `wave`, none of this have any affect visually or functionally, but it is a better change code wise.

Issued addressed:

* Duplicate `id` in same page
* Missing `title` for iframes