### PR TITLE
Update action methods

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
       # only needed when publishing to Github (ghcr.io)
       - name: Log in to Github Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           # will run as the user who triggered the action, using its token
@@ -49,7 +49,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.images }}
           tags: |
@@ -58,7 +58,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Build and Publish
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: ${{ matrix.dockerfile }}
           context: .

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,8 +4,6 @@
 name: Check broken links (htmltest)
 on:
   workflow_dispatch:
-    branches:
-      - develop
   schedule:
     - cron: '25 8 1-7 * 3'
 
@@ -17,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Set up Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "latest"
           
@@ -32,7 +30,7 @@ jobs:
           config: .github/htmltest-config.yml
       
       - name: Archive htmltest results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: htmltest-report
           path: tmp/.htmltest/htmltest.log

--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -30,7 +30,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-branch

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -36,7 +36,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-cron


### PR DESCRIPTION
Github decides to use `node v20` for actions from December 2024, so action action methods using older version of node displays warnings about this.

In this PR the relevant methods are updated to use the latest versions.