### PR TITLE
Trivy workflow fix

### DIFF
--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.9.2
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: "fs"
           ignore-unfixed: true

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -28,7 +28,9 @@ jobs:
         run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.9.2
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db'
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'ghcr.io/${{ env.REPOSITORY_OWNER }}/pathogens-portal:develop'
           format: 'sarif'


### PR DESCRIPTION
`trivy` workflow fails randomly due to too many request error. Trivy knows this and currently trying to fix it, as a work around they have also hosted their DB file in `ECR`. So adding the ecr repo via ENV variable `TRIVY_DB_REPOSITORY ` should reduce the problem if not fixing it.