### PR TITLE
Hugo version update

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # Use alpine Linux, download desired version of HUGO and build html files
 FROM alpine:3.19.1 AS build
 RUN apk add --no-cache wget=1.21.4-r0
-ARG HUGO_VERSION="0.123.7"
+ARG HUGO_VERSION="0.139.3"
 ARG HUGO_ENV_ARG
 WORKDIR /src
 COPY ./ /src

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.11.1/.schema/devbox.schema.json",
 	"packages": [
-		"hugo@0.123",
+		"hugo@0.139",
 		"nodejs@22"
 	],
 	"env": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,51 +1,51 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "hugo@0.123": {
-      "last_modified": "2024-03-10T19:04:55Z",
-      "resolved": "github:NixOS/nixpkgs/d40e866b1f98698d454dad8f592fe7616ff705a4#hugo",
+    "hugo@0.139": {
+      "last_modified": "2024-11-28T07:51:56Z",
+      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#hugo",
       "source": "devbox-search",
-      "version": "0.123.8",
+      "version": "0.139.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/sw7bkq2n2gbwhh5r92h1bp1wrrdwlab2-hugo-0.123.8",
+              "path": "/nix/store/cjkcbn1wkzn6d8syb1cyppdq9h50rkzp-hugo-0.139.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/sw7bkq2n2gbwhh5r92h1bp1wrrdwlab2-hugo-0.123.8"
+          "store_path": "/nix/store/cjkcbn1wkzn6d8syb1cyppdq9h50rkzp-hugo-0.139.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/61c0jw2y148vfsmgpdlrqjq3jkwrbfsd-hugo-0.123.8",
+              "path": "/nix/store/mnxim04ppi0dqmzhzkh45lavmfra4n2g-hugo-0.139.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/61c0jw2y148vfsmgpdlrqjq3jkwrbfsd-hugo-0.123.8"
+          "store_path": "/nix/store/mnxim04ppi0dqmzhzkh45lavmfra4n2g-hugo-0.139.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lz18cgzsd8cl7h3fxnm8d5ahq6whzl3s-hugo-0.123.8",
+              "path": "/nix/store/96cinf0bmch7gkrq1izvy2lhwrdi0p1m-hugo-0.139.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/lz18cgzsd8cl7h3fxnm8d5ahq6whzl3s-hugo-0.123.8"
+          "store_path": "/nix/store/96cinf0bmch7gkrq1izvy2lhwrdi0p1m-hugo-0.139.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/5rj0cbz9g0rsf3cxnfqr0f46z38s5psc-hugo-0.123.8",
+              "path": "/nix/store/13g2k2qivwizb70gi533da0c13grgfk7-hugo-0.139.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/5rj0cbz9g0rsf3cxnfqr0f46z38s5psc-hugo-0.123.8"
+          "store_path": "/nix/store/13g2k2qivwizb70gi533da0c13grgfk7-hugo-0.139.0"
         }
       }
     },

--- a/layouts/data_table/list.html
+++ b/layouts/data_table/list.html
@@ -59,7 +59,7 @@
 
 {{ $datatypes_to_display := slice }}
 {{ $path := strings.TrimPrefix "/sv" (strings.TrimRight "/" (string .Page.RelPermalink)) }}
-{{ with .Sites.First.GetPage $path }}
+{{ with .Sites.Default.GetPage $path }}
 {{ $datatypes_to_display = .Params.datatypes_to_display }}
 {{ end }}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -69,7 +69,7 @@
 
     {{ $datatypes_to_display := slice }}
     {{ $path := strings.TrimPrefix "/sv" (strings.TrimRight "/" (string .Page.RelPermalink)) }}
-    {{ with .Sites.First.GetPage $path }} {{ $datatypes_to_display = .Params.datatypes_to_display }} {{ end }}
+    {{ with .Sites.Default.GetPage $path }} {{ $datatypes_to_display = .Params.datatypes_to_display }} {{ end }}
 
     {{ range .Site.Menus.homepage_available_data }}
     <div class="row mt-4 mb-2 pt-2">


### PR DESCRIPTION
Update Hugo version from `0.123.7` to `0.139.3` and solve the associated deprecation errors.

Closes [FREYA-1125](https://scilifelab.atlassian.net/browse/FREYA-1125)