### PR TITLE
Dropdown menus and ToC fix overlap

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
   <!-- Bootstrap icons -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-  <!-- Covid Portal CSS -->
+  <!-- Pathogens Portal CSS -->
   <link rel="stylesheet" href="/css/styles.css">
 
   <!-- jQuery -->

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,4 +1,4 @@
-<aside class="sticky-top toc pt-2">
+<aside class="toc pt-2">
     <h5>{{ if eq $.Site.Language.LanguageName "Svenska" }}Innehållsförteckning{{ else }}Table of Contents{{ end }}</h5>
     {{ .TableOfContents }}
 </aside>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -260,6 +260,12 @@ a.nav-link:active {
   color: #6c757d;
 }
 
+.toc {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
 .toc ul {
   padding-left: 1.5rem;
   margin-bottom: 0.5rem;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -225,12 +225,6 @@ a.nav-link:active {
   text-align: left;
 }
 
-/* Position tweak for sub dropdown */
-.dropdown-menu .dropdown-menu {
-  top: -0.55rem !important;
-  left: -0.18rem !important;
-}
-
 @media (max-width: 1199px) {
   .main_menu .border-right {
     border: 0px solid !important;


### PR DESCRIPTION
Fix the overlapping issue between dropdown menus and tables of content.
Also clean unused class in CSS style sheet.

Closes [FREYA-1105](https://scilifelab.atlassian.net/browse/FREYA-1105)