### PR TITLE
FREYA-1118: Add PLP Test reporting section to the project page

### DIFF
--- a/content/english/resources/integrative_outbreak_sim.md
+++ b/content/english/resources/integrative_outbreak_sim.md
@@ -42,8 +42,19 @@ In total, there are 10 participants in 11 institutes:
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+###### Phase 1
+
 <div class="plot_wrapper mb-3">
-  <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis.json" height="550px" >}}</div>
+  <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis-phase-1.json" height="550px" >}}</div>
 </div>
 
-**Code used to produce plot:** [Script to produce plot](https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/blob/main/PLP/PLP-TEST-labs-analysis.py).
+**Code used to produce plot:** [Script to produce plot](https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/blob/main/PLP/PLP-TEST-labs-analysis-phase-1.py).
+
+
+###### Phase 2
+
+<div class="plot_wrapper mb-3">
+  <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis-phase-2.json" height="550px" >}}</div>
+</div>
+
+**Code used to produce plot:** [Script to produce plot](https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/blob/main/PLP/PLP-TEST-labs-analysis-phase-2.py).

--- a/content/english/resources/integrative_outbreak_sim.md
+++ b/content/english/resources/integrative_outbreak_sim.md
@@ -40,9 +40,35 @@ In total, there are 10 participants in 11 institutes:
 
 ##### Outcomes
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+###### Summary of the sequence of events
 
-###### Phase 1
+- *Weeks 33–38:* Samples for the project were prepared.
+- *Week 39 (Sept 23–29):* Samples were sent out and held by the delivery company until October 2nd (13:00), and were delivered to labs with case information.
+- *Weeks 39–41 (Oct 2–21):* Labs tested the first set of samples, logging activities chronologically. The testing deadline was October 21 (8:00).
+- *23rd Oct 2024:*  Stage 1 Discussion Meeting. Analysis methods and procedures were discussed and compared.
+- *Week 41 (Oct 21–27):* Second set of samples, sent out on October 23 (13:00).
+- *Weeks 42–44 (Oct 23–Nov 4):* Labs tested the second set of samples, logging their activities chronologically. The deadline was November 4 (8:00).
+- *Week 47 (26th Nov):* Stage 2 Discussion Meeting. Analysis methods and procedures were discussed and compared.
+
+The labs recorded their procedures chronologically in a pre-prepared log template.
+The granularity of data which labs could share was limited by data governance regulation.
+All the labs received different samples and their analysis methods remained unique to address the sample.
+During the first phase of the outbreak simulation the labs we given unidentified sample for pathogen identification, the analysis time varied from 6 days to 26 days with an average of 14 days.
+The second phase included testing a larger sample size of unidentified sample to deduce and group them based on results, the analysis time was  between 12 days to 26 days with an average of 12 days. 
+
+The different analysis methods used during the course of pathogen identification were reported as:
+
+- Incubation/Cultivation
+- RNA and DNA Extractions
+- Nanopore Squencing, Amplicon sequencing, RNA Immunoprecipitation Sequencing (RIP-seq), Sequencing
+- Metagenomics
+- Matrix-assisted laser desorption/ionization
+- Risk Assessment
+- Technical and Medical Assessment
+    
+The pathogens identified during the outbreak simulation was reported to be Christensenella Hongkongensis by Lab 2 and Catabacter Hongkongensis by Lab 3.
+
+###### Lab activities visualisations: Phase 1
 
 <div class="plot_wrapper mb-3">
   <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis-phase-1.json" height="550px" >}}</div>
@@ -51,7 +77,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 **Code used to produce plot:** [Script to produce plot](https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/blob/main/PLP/PLP-TEST-labs-analysis-phase-1.py).
 
 
-###### Phase 2
+###### Lab activities visualisations: Phase 2
 
 <div class="plot_wrapper mb-3">
   <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis-phase-2.json" height="550px" >}}</div>

--- a/content/english/resources/integrative_outbreak_sim.md
+++ b/content/english/resources/integrative_outbreak_sim.md
@@ -11,6 +11,7 @@ for_background_table:
   pi: René Kaden
   pi_affiliation: Uppsala University
   lab: Uppsala University Hospital
+plotly: true
 ---
 
 This collaborative project, including 6 PLP partners and the National Veterinary Institute (SVA) (see the [full list of participants](#list-of-participants) below), is designed to simulate an outbreak scenario by dispatching clinical samples that are spiked with unusual microorganisms to the contributing clinical microbiology laboratories. These samples are delivered in a manner that facilitates enrichment and mimick authentic patient and wastewater samples. The scenarios may encompass complex, potentially zoonotic outbreaks, thus embracing the One Health concept by engaging partners from both human and animal health.
@@ -36,3 +37,13 @@ In total, there are 10 participants in 11 institutes:
 - National Veterinary Institute (SVA)
 - Swedish Pathogens Portal
 - The Swedish University of Agricultural Sciences (SLU)
+
+##### Outcomes
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+<div class="plot_wrapper mb-3">
+  <div class="table-responsive" style="min-width: 800px">{{< plotly json="https://blobserver.dc.scilifelab.se/blob/PLP-TEST-labs-analysis.json" height="550px" >}}</div>
+</div>
+
+**Code used to produce plot:** [Script to produce plot](https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/blob/main/PLP/PLP-TEST-labs-analysis.py).


### PR DESCRIPTION
Add an "Outcomes" section to the [PLP Test project page](http://localhost:1313/resources/integrative_outbreak_sim/).
This new section comprises a brief summary of the project outcomes and two visualisations from https://github.com/ScilifelabDataCentre/pathogens-portal-visualisations/pull/114.

Closes [FREYA-1118](https://scilifelab.atlassian.net/browse/FREYA-1118).