### PR TITLE
Fixed dead links related to wastewater dashboards

### DIFF
--- a/content/english/dashboards/wastewater_background.md
+++ b/content/english/dashboards/wastewater_background.md
@@ -19,7 +19,7 @@ Please note that each laboratory processes and analyses their wastewater samples
 
 - [**Influenza quantification**](/dashboards/influenza_quantification/): Data, visualisations, and information related to the quantification of Influenza viruses in wastewater in different areas of Sweden. These data are collected, analysed, and shared by the SEEC-SLU.
 
-- [**RSV quantification**](/dashboards/wastewater_rsv/): Data, visualisations, and information related to the quantification of Respiratory Syncytial Virus (RSV) in wastewater in different areas of Sweden. These data are collected, analysed, and shared by the SEEC-SLU.
+- [**RSV quantification**](/dashboards/rsv_quantification/): Data, visualisations, and information related to the quantification of Respiratory Syncytial Virus (RSV) in wastewater in different areas of Sweden. These data are collected, analysed, and shared by the SEEC-SLU.
 
 ## Availability of code
 

--- a/content/english/resources/enbiflu.md
+++ b/content/english/resources/enbiflu.md
@@ -6,7 +6,7 @@ resource_info:
   name: "EnBiFlu, testing the efficiency of multifaceted environmental assessment of avian influenza threats and outbreaks"
   pi: Anna J. Székely
   host_organisation: "Swedish University of Agricultural Sciences, SLU."
-  data_etc: "[Dashboard: The amount of SARS-CoV-2 virus in wastewater across Sweden](https://www.pathogens.se/dashboards/wastewater/)"
+  data_etc: "[Dashboard: SARS-CoV-2 Quantification](/dashboards/covid_quantification/)"
   publications_etc:
   webpage:
   contact: "Anna J. Székely<br>Researcher<br>Email: [anna.szekely@slu.se](mailto:anna.szekely@slu.se)"

--- a/content/svenska/dashboards/wastewater_background.md
+++ b/content/svenska/dashboards/wastewater_background.md
@@ -21,7 +21,7 @@ Notera att det förekommer mindre skillnader mellan detektionsmetoderna som grup
 
 - [**Influenza quantification**](/dashboards/influenza_quantification/): Data, visualiseringar och information kopplad till kvantifiering av influensavirus i avloppsvatten från olika delar av Sverige. Dessa data samlas in, analyseras och delas av SEEC-noden vid Sveriges lantbruksuniversitet (SLU).
 
-- [**RSV quantification**](/dashboards/wastewater_rsv/): Data, visualiseringar och information relaterad till kvantifiering av respiratoriskt syncytialvirus (RSV) i avloppsvatten i olika delar av Sverige. Dessa data samlas in, analyseras och delas av SEEC-SLU.
+- [**RSV quantification**](/dashboards/rsv_quantification/): Data, visualiseringar och information relaterad till kvantifiering av respiratoriskt syncytialvirus (RSV) i avloppsvatten i olika delar av Sverige. Dessa data samlas in, analyseras och delas av SEEC-SLU.
 
 ## Tillgänglighet av källkod
 


### PR DESCRIPTION
Linked to Jira issue [FREYA-1179](https://scilifelab.atlassian.net/browse/FREYA-1179)
There was another broken link identified for RSV dashboard which is fixed. Jira issue [FREYA-1205](https://scilifelab.atlassian.net/browse/FREYA-1205)