### PR TITLE
FREYA-1197: Wrap ToC sticky behaviour in media query

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -254,8 +254,8 @@ a.nav-link:active {
   color: #6c757d;
 }
 
+/* Table of Content */
 .toc {
-  position: sticky;
   top: 0;
   z-index: 999;
 }
@@ -266,6 +266,12 @@ a.nav-link:active {
 }
 .toc ul ul {
   font-size: 0.9rem;
+}
+
+@media all and (min-width: 767px) {
+  .toc {
+    position: sticky;
+  }
 }
 
 .content ul:not([class]),


### PR DESCRIPTION
On smaller viewports, the ToC was overlapping the content. Conditioning the sticky position to larger viewports where the ToC is on the side solves the issue as we don't need sticky ToC on smaller viewports.

Closes [FREYA-1197](https://scilifelab.atlassian.net/browse/FREYA-1197).