### PR TITLE
Add CC license and project info in footer

### DIFF
--- a/content/english/resources/integrative_outbreak_sim.md
+++ b/content/english/resources/integrative_outbreak_sim.md
@@ -53,8 +53,8 @@ In total, there are 10 participants in 11 institutes:
 The labs recorded their procedures chronologically in a pre-prepared log template.
 The granularity of data which labs could share was limited by data governance regulation.
 All the labs received different samples and their analysis methods remained unique to address the sample.
-During the first phase of the outbreak simulation the labs we given unidentified sample for pathogen identification, the analysis time varied from 6 days to 26 days with an average of 14 days.
-The second phase included testing a larger sample size of unidentified sample to deduce and group them based on results, the analysis time was  between 12 days to 26 days with an average of 12 days. 
+During the first phase of the outbreak simulation the labs we were given an unidentified sample for pathogen identification, the analysis time varied from 6 days to 26 days with an average of 14 days.
+The second phase included testing a larger sample size of unidentified sample to deduce and group them based on results, the analysis time was between 12 days to 26 days with an average of 12 days. 
 
 The different analysis methods used during the course of pathogen identification were reported as:
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -68,16 +68,58 @@
   </div>
   
   <!-- The hugo env value is passed via github action, during image building -->
+  <!-- This will have version for production instance-->
   {{ $env_info := split hugo.Environment "-" }}
   {{ $git_sha := index $env_info 1 }}
   {{ $code_version := cond (strings.HasPrefix $git_sha "v") $git_sha (substr $git_sha 0 7) }}
-  <div class="d-flex justify-content-center small mt-2">
-    <a target="_blank"
-       href="https://github.com/ScilifelabDataCentre/pathogens-portal{{ with $code_version }}/tree/{{ $code_version }}{{ end }}">
-      {{ if eq $.Site.Language.LanguageName "Svenska" }}Källkod finns tillgänglig på GitHub{{ else }}Website code is available on Github{{ end }} 
-    </a>
-      {{ with $code_version }}<span class="ps-1 text-muted">({{ $code_version }})</span>{{ end }}
+
+  <!-- License and project info -->
+  <div class="row mt-2">
+    <div class="col-md small px-5 px-md-2 pt-1">
+      {{ if eq $.Site.Language.LanguageName "English" }}
+        <p class="mb-2">
+          This project is supported by the National Institute Of Allergy And Infectious Diseases (NIAID) of the National Institutes of Health (NIH) 
+          under Award Number U24AI183840. The content is solely the responsibility of the authors and does not necessarily represent the official 
+          views of the National Institutes of Health.
+        </p>
+        <p class="mb-1">
+          The website content is licensed under the <a target="_blank" rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+          CC-BY 4.0 International License <i class="bi bi-cc-circle" style="vertical-align:text-top;"></i></a>
+        </p>
+        <p>
+          The website code is licensed under the 
+          <a target="_blank" rel="license" href="https://github.com/ScilifelabDataCentre/pathogens-portal/blob/{{ with $code_version }}{{ . }}{{ else }}develop{{ end }}/LICENSE">
+              MIT license
+          </a> 
+          and it is available on 
+          <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal{{ with $code_version }}/tree/{{ $code_version }}{{ end }}">
+              Github {{ with $code_version }}<span class="ps-1 text-muted">({{ $code_version }})</span>{{ end }}
+          </a>
+        </p>
+      {{ else }}
+        <p class="mb-2">
+          Detta projekt stöds av "National Institute Of Allergy And Infectious Diseases (NIAID) of the National Institutes of Health (NIH)" under 
+          tilldelningsnummer U24AI183840. Innehållet är enbart författarnas ansvar och representerar inte nödvändigtvis "National Institutes of Healths" 
+          officiella ståndpunkter.
+        </p>
+        <p class="mb-1">
+          Webbplatsens innehåll är licensierat under <a target="_blank" rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+          CC-BY 4.0 International License <i class="bi bi-cc-circle" style="vertical-align:text-top;"></i></a>
+        </p>
+        <p>
+          Webbplatsens kod är licensierad under 
+          <a target="_blank" rel="license" href="https://github.com/ScilifelabDataCentre/pathogens-portal/blob/{{ with $code_version }}{{ . }}{{ else }}develop{{ end }}/LICENSE">
+              MIT license
+          </a> 
+          och finns tillgänglig på  
+          <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal{{ with $code_version }}/tree/{{ $code_version }}{{ end }}">
+              Github {{ with $code_version }}<span class="ps-1 text-muted">({{ $code_version }})</span>{{ end }}
+          </a>
+        </p>
+      {{ end }}
+    </div>
   </div>
+
 </footer>
 
 <!-- Bootstrap Bundle with Popper -->


### PR DESCRIPTION
Add project info and CC-BY 4 license info in footer. The project info text should be same as the one in the [central pathogens portal](https://www.pathogensportal.org/), so it was a copy paste. Just added the institute's abbreviations for some clarity.

This PR also includes a commit to fix the typo's in PR #1216 