### PR TITLE
Fixes broken link of enteric virus Dataset

### DIFF
--- a/content/english/dashboards/enteric_quantification/_index.md
+++ b/content/english/dashboards/enteric_quantification/_index.md
@@ -62,7 +62,7 @@ Please see [the section with summary information about the viruses](#basic-virus
 
 ###### **Download the data:**
 
-[Quantification of SARS-CoV-2 and enteric viruses in wastewater](https://blobserver.dckube.scilifelab.se/blob/wastewater_data_gu_allviruses.xlsx). Results are available for SARS-CoV-2 and enteric viruses from week 20 of 2023. Updated weekly.
+[Quantification of SARS-CoV-2 and enteric viruses in wastewater](https://blobserver.dc.scilifelab.se/blob/wastewater_data_gu_allviruses.xlsx). Results are available for SARS-CoV-2 and enteric viruses from week 20 of 2023. Updated weekly.
 
 **Contact:** <helene.norder@gu.se>
 

--- a/content/svenska/dashboards/enteric_quantification/_index.md
+++ b/content/svenska/dashboards/enteric_quantification/_index.md
@@ -65,7 +65,7 @@ Vänligen se [avsnittet med sammanfattande information om virusen](#grundläggan
 
 ###### **Nedladdning av data:**
 
-[Kvantifiering av mängd SARS-CoV-2 och enteriska virus i avloppsvatten](https://blobserver.dckube.scilifelab.se/blob/wastewater_data_gu_allviruses.xlsx). Results för SARS-CoV-2 mätningar är tillgängliga från vecka 20 2023. Uppdatering sker varje vecka.
+[Kvantifiering av mängd SARS-CoV-2 och enteriska virus i avloppsvatten](https://blobserver.dc.scilifelab.se/blob/wastewater_data_gu_allviruses.xlsx). Results för SARS-CoV-2 mätningar är tillgängliga från vecka 20 2023. Uppdatering sker varje vecka.
 
 **Kontakt:** <helene.norder@gu.se>
 


### PR DESCRIPTION
This pull request includes minor changes to correct URLs in two markdown files.

* [`content/english/dashboards/enteric_quantification/_index.md`](diffhunk://#diff-856213f6b7dd73fcd73e74c7e64c366bf121319be8467d0904a6578a5078d61dL65-R65): Corrected the URL for downloading the quantification data of SARS-CoV-2 and enteric viruses in wastewater.
* [`content/svenska/dashboards/enteric_quantification/_index.md`](diffhunk://#diff-71907d28ec736720a22317bf73a6fc2f43d282d5a2dcc9ff723a0265f0b57c07L68-R68): Corrected the URL for downloading the quantification data of SARS-CoV-2 and enteric viruses in wastewater.

Closes: [FREYA-1250](https://scilifelab.atlassian.net/browse/FREYA-1250)
