### PR TITLE
Use right blob for clinical micro UU dashboard

### DIFF
--- a/layouts/shortcodes/clinmicro_dynamic_content.html
+++ b/layouts/shortcodes/clinmicro_dynamic_content.html
@@ -1,7 +1,7 @@
 <script>
    var metaDataFiles = new Array(
      {
-       "url": "https://blobserver.dc.scilifelab.se/blob/lineage_four_recent.json/info.json",
+       "url": "https://blobserver.dc.scilifelab.se/blob/lineage-cleaned-data.csv/info.json",
        "to_update": ["last_modified_uuclinmicro"],
        "type": "dataset"
      },


### PR DESCRIPTION
Last updated date is not displaying in [this](https://www.pathogens.se/dashboards/variants_region_uppsala/) dashboard as it is still try to use old (non-existent) blob, so changing it to use the right blob.