### PR TITLE
Freya-1384:Add Netherlands Pathogens Portal

### DIFF
--- a/content/english/other_national_portals.md
+++ b/content/english/other_national_portals.md
@@ -17,9 +17,9 @@ The [Pathogens Data Network (PDN)](https://pathogendatanetwork.org) was formed i
 
 #### List of Pathogen Portals
 
-- [Pathogens Portal Switzerland](https://pathogensportal.ch/)
+- [Pathogens Portal Netherlands](https://www.pathogensportal.nl/)
 - [Pathogens Portal Norway](https://pathogens.no/)
-- [Pathogens Portal Netherlands](https://www.pathogensportal.nl/index.html)
+- [Pathogens Portal Switzerland](https://pathogensportal.ch/)
 
 ### National COVID-19 Data Portals
 

--- a/content/english/other_national_portals.md
+++ b/content/english/other_national_portals.md
@@ -7,11 +7,27 @@ menu:
     weight: 20
 ---
 
+### National Pathogens Portals
+
+In July 2023, the European Molecular Biology Laboratory's European Bioinformatics Institute ([EMBL-EBI](https://www.ebi.ac.uk/)) launched a new version of the [Pathogens Portal](https://www.pathogensportal.org/). This reflected a global move towards general pandemic preparedness, and away from COVID-19 specifically. The Pathogens Portal holds data and information about multiple pathogens and pandemic preparedness in general.
+
+In August 2023, the Swedish Pathogens Portal was launched, becoming the first national pathogens portal node ([see our news on the launch](https://www.pathogens.se/updates/pathogens_portal/)). The Swedish Pathogens Portal was soon used as a basis for other national pathogens portals.
+
+The [Pathogens Data Network (PDN)](https://pathogendatanetwork.org) was formed in 2024. One of its aims was to create a knowledge base enabling access to pathogens data. Work on the knowledge base was co-led by SciLifeLab Data Centre and EMBL-EBI. As part of this work, SciLifeLab Data Centre created [openly available code for a minimal local/national pathogens portal](https://github.com/ScilifelabDataCentre/node-pathogens-portal), based on the Swedish Pathogens Portal, which they developed, to facilitate the launch of other pathogens portals.
+
+#### List of Pathogen Portals
+
+- [Pathogens Portal Switzerland](https://pathogensportal.ch/)
+- [Pathogens Portal Norway](https://pathogens.no/)
+- [Pathogens Portal Netherlands](https://www.pathogensportal.nl/index.html)
+
 ### National COVID-19 Data Portals
 
-The Swedish Pathogens Portal originated as the 'Swedish COVID-19 Data Portal'. It was the first national node of the [European COVID-19 Data Platform](https://covid19dataportal.org/); a Europe-wide platform allowing researchers to upload, access, and analyse COVID-19 related datasets. The [European COVID-19 Data Platform](https://covid19dataportal.org/) was launched in the spring of 2020 when the European Commission [took the initiative to develop a European data sharing platform for COVID-19 research efforts](https://www.embl.org/news/science/embl-ebi-launches-covid-19-data-portal/). It is operated by the European Molecular Biology Laboratory - European Bioinformatics Institute (EMBL-EBI) and [partners](https://www.covid19dataportal.org/partners).
+The Swedish Pathogens Portal was originally launched as the 'Swedish COVID-19 Data Portal'. It was the first national node of the [European COVID-19 Data Platform](https://covid19dataportal.org/); a Europe-wide platform allowing researchers to upload, access, and analyse COVID-19 related datasets. The [European COVID-19 Data Platform](https://covid19dataportal.org/) was launched in the spring of 2020 when the European Commission [took the initiative to develop a European data sharing platform for COVID-19 research efforts](https://www.embl.org/news/science/embl-ebi-launches-covid-19-data-portal/). It is operated by the European Molecular Biology Laboratory - European Bioinformatics Institute (EMBL-EBI) and [partners](https://www.covid19dataportal.org/partners).
 
-Multiple other countries used the Swedish portal as a basis for their own national portals, with many making use of [our source code](https://github.com/ScilifelabDataCentre/pathogens-portal) to get started! Below is a list of national COVID-19 Data Portals established:
+Multiple other countries used the Swedish portal as a basis for their own national node, with some using the source code directly as a basis.
+
+#### List of COVID-19 Data Portals
 
 - [COVID-19 Data Portal Estonia](https://covid19dataportal.ee)
 - [COVID-19 Data Portal Greece](https://www.covid19dataportal.gr)
@@ -24,12 +40,3 @@ Multiple other countries used the Swedish portal as a basis for their own nation
 - [COVID-19 Data Portal Spain](https://www.covid19dataportal.es)
 
 Norway and Turkey ([see Turkey's archived portal](https://www.loc.gov/item/lcwaN0030712/)) also had national COVID-19 data portals throughout the COVID-19 pandemic.
-
-### National Pathogens Portals
-
-In July 2023, the European Molecular Biology Laboratory's European Bioinformatics Institute ([EMBL-EBI](https://www.ebi.ac.uk/)) launched a new version of the [Pathogens Portal](https://www.pathogensportal.org/). This reflects global move towards general pandemic preparedness, and away from just COVID-19 specifically. The Pathogens Portal holds data and information about multiple pathogens and pandemic preparedness in general.
-
-In August 2023, we transitioned the Swedish COVID-19 Data Portal into the first national node of the Pathogens Portal ([read our news](https://www.pathogens.se/updates/pathogens_portal/)). It is now known as the Swedish Pathogens Portal. Other countries have now followed suit, again using the Swedish portal as a basis for their own national portals (see e.g. [news on the launch of the Swiss and Norwegian Portals](https://www.pathogensportal.org/news/swiss-and-norwegian-national-pathogens-portals-launched?nid=173)).
-
-- [Pathogens Portal Switzerland](https://pathogensportal.ch/)
-- [Pathogens Portal Norway](https://pathogens.no/)

--- a/content/english/updates/PDN_news.md
+++ b/content/english/updates/PDN_news.md
@@ -6,7 +6,7 @@ banner: /updates/banners/network_PDN.jpg
 banner_caption: "Representation of a network"
 ---
 
-SciLifeLab Data Centre is part of a major international initiative to advance infectious disease data sharing. Funded by the [National Institutes of Health (NIH)](https://www.nih.gov/), the Pathogen Data Network (PDN) will build infrastructure, tools, and training to support FAIR data practices. The four-year project brings together 12 international partners and is coordinated by the [SIB Swiss Institute of Bioinformatics](https://www.sib.swiss/)).
+SciLifeLab Data Centre is part of a major international initiative to advance infectious disease data sharing. Funded by the [National Institutes of Health (NIH)](https://www.nih.gov/), the Pathogen Data Network (PDN) will build infrastructure, tools, and training to support FAIR data practices. The four-year project brings together 12 international partners and is coordinated by the [SIB Swiss Institute of Bioinformatics](https://www.sib.swiss/).
 
 > ‘The Pathogen Data Network aims to become a global, diverse and inclusive hub for distributed resources that foster infectious-disease FAIR data management and processing.’ says Aitana Neves, Associate Director of Clinical Bioinformatics at SIB. ‘With a strong focus on support, capacity building, and trustworthiness, everyone interested is welcome to join its Open Community Forum to actively engage and provide feedback to the resources that will be developed.’
 


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR restructures the national portal page and adds the latest pathogens portal from the Netherlands. It also fixes a typo on the PDN news (removes and extra ) ) 
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Added Netherlands portal
- fixed typo in news
- makes the national pathogens portals the main focus of the national portals page 

### 🔍 Notes for Reviewers
Please check links work and read text to ensure that it is correctly edited.
 
### ✅ Checklist
- [X] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [X] Jira / Github issue is linked
- [X] Assignee is selected
- [X] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [X] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1384](https://scilifelab.atlassian.net/browse/FREYA-1384?atlOrigin=eyJpIjoiY2Q0Y2UwMDk2NWY4NDhhNmJjYjVjOGJjNjNhNGJjMzIiLCJwIjoiaiJ9)
