### PR TITLE
FREYA-1406: Alert on publications dashboard archive

### DIFF
--- a/content/english/publications/_index.md
+++ b/content/english/publications/_index.md
@@ -6,6 +6,10 @@ menu:
     name: Swedish COVID-19 Publications
 ---
 
+<div class="alert alert-info">
+  <span class="bi bi-exclamation-triangle-fill"> This dataset will no longer be updated. New features are under development that will show publications for more pathogens.</span>
+</div>
+
 This section presents a list of published scientific journal articles and preprints on COVID-19 and SARS-CoV-2 where at least one author has an affiliation with a Swedish research institute. Note that this database is primarily a manually curated database and thus it may not be exhaustive. Note that from May 2023, we began to use the Europe PMC REST API to idenfy publications. The scripts that we use to do this are [openly available on GitHub](https://github.com/ScilifelabDataCentre/pathogens-portal-scripts/tree/main/All_publications) and can be reused with other pathogens.
 
 If you would like your publication to be added here or information about your publication to be corrected, [please get in touch with us](/suggestions/). We also have a [page with visualisations of the publications in this database](/dashboards/covid_publications/).


### PR DESCRIPTION
Publication dashboard will no longer be updated, and to notify that new feature is under development to include more pathogens.

- Added the alert text informing the archival and new feature under development.

Closes: [FREYA-1406](https://scilifelab.atlassian.net/jira/software/projects/FREYA/boards/17/backlog?assignee=712020%3Aff77c32d-3ee1-4ef7-b1d0-1bbf05509bcf&selectedIssue=FREYA-1406)
