### PR TITLE
feat(ui): enable HTML links in banner title with custom styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -836,3 +836,9 @@ iframe#matoOpOut {
 .text-muted-dark {
   color: rgba(0, 0, 0, 0.65);
 }
+
+/* Banner title links should appear as normal text */
+#home-banner a {
+  color: inherit;
+  /* text-decoration: none; */
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -276,7 +276,7 @@
         if (title) {
           if (title[lang]) {
             const titleElement = document.querySelector('h2#home-banner');
-            titleElement.textContent = title[lang];
+            titleElement.innerHTML = title[lang];
           } else {
             console.warn('No title found for the language.');
           }


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR adds HTML link support to the banner title system, allowing clickable links to be embedded in banner text while maintaining the visual appearance of normal text.
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Changed `textContent` to `innerHTML` in banner title JavaScript to support HTML rendering
- Added CSS styling for `#home-banner a` to make links appear as normal text (inherit color, no underline)

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 - Test with JSON data containing HTML links like: `"<a href='https://www.google.com/'>Pathogens Portal Sweden</a>: support for pandemic preparedness"`
 - You can use testing file: https://blobserver.dc.scilifelab.se/blob/test-freya-banner.json/
 
### ✅ Checklist
- [x] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [x] Jira / Github issue is linked
- [x] Assignee is selected
- [x] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [x] Automated checks pass
- [x] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1665](https://scilifelab.atlassian.net/browse/FREYA-1665)
