### PR TITLE
FREYA-1658: Update national portal pages

### DIFF
--- a/content/english/other_national_portals.md
+++ b/content/english/other_national_portals.md
@@ -27,18 +27,4 @@ The [Pathogens Data Network (PDN)](https://pathogendatanetwork.org) was formed i
 
 The Swedish Pathogens Portal was originally launched as the 'Swedish COVID-19 Data Portal'. It was the first national node of the [European COVID-19 Data Platform](https://covid19dataportal.org/); a Europe-wide platform allowing researchers to upload, access, and analyse COVID-19 related datasets. The [European COVID-19 Data Platform](https://covid19dataportal.org/) was launched in the spring of 2020 when the European Commission [took the initiative to develop a European data sharing platform for COVID-19 research efforts](https://www.embl.org/news/science/embl-ebi-launches-covid-19-data-portal/). It is operated by the European Molecular Biology Laboratory - European Bioinformatics Institute (EMBL-EBI) and [partners](https://www.covid19dataportal.org/partners).
 
-Multiple other countries used the Swedish portal as a basis for their own national node, with some using the source code directly as a basis.
-
-#### List of COVID-19 Data Portals
-
-- [COVID-19 Data Portal Estonia](https://covid19dataportal.ee)
-- [COVID-19 Data Portal Greece](https://www.covid19dataportal.gr)
-- [COVID-19 Data Portal Italy](https://www.covid19dataportal.it)
-- [COVID-19 Data Portal Japan](https://covid19dataportal.jp)
-- [COVID-19 Data Portal Luxembourg](https://covid19dataportal.lu)
-- [COVID-19 Data Portal Netherlands](https://www.covid19dataportal.nl)
-- [COVID-19 Data Portal Poland](https://covid19dataportal.pl)
-- [COVID-19 Data Portal Slovenia](https://covid19dataportal.si)
-- [COVID-19 Data Portal Spain](https://www.covid19dataportal.es)
-
-Norway and Turkey ([see Turkey's archived portal](https://www.loc.gov/item/lcwaN0030712/)) also had national COVID-19 data portals throughout the COVID-19 pandemic.
+In total, 12 national nodes (in Estonia, Greece, Italy, Japan, Luxembourg, the Netherlands, Norway, Poland, Slovenia, Spain, Sweden, and Turkey) were launched during the pandemic. Many of these countries used the Swedish portal as a basis for their own national node, with some using the source code directly as a basis.


### PR DESCRIPTION
This removes many of the broken links for the COVID-19 portals

### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR updates the national portal page to remove many of the dead links whilst keeping the relevant information. This will be replaced entirely in the new version of the portal
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Removed links from covid nodes
- summarised information 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [X] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [X] Jira / Github issue is linked
- [X] Assignee is selected
- [X] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [X] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1658](https://scilifelab.atlassian.net/browse/FREYA-1658?atlOrigin=eyJpIjoiNzkzYzUzMTQxZmNhNDE3ZWJhZDhhOGJmYTAzMzEyYmUiLCJwIjoiaiJ9)
