### PR TITLE
Remove redundant front matter

### DIFF
--- a/content/english/dashboards/multidisease_serology.md
+++ b/content/english/dashboards/multidisease_serology.md
@@ -2,7 +2,6 @@
 title: Multi-disease serology
 description: A summary of the progress in developing a multi-disease serology assay, a key component of pandemic preparedness. Information about externally produced antigens is also provided.
 banner: /dashboard_thumbs/multi-disease-serology.jpg
-toc: false
 menu:
   dashboard_menu:
     identifier: multi_disease_serology

--- a/content/english/highlights/poliovirus_replication.md
+++ b/content/english/highlights/poliovirus_replication.md
@@ -11,7 +11,6 @@ tags: [Polio, Pandemic preparedness, Autophagy, Cryo]
 aliases:
     - /news/poliovirus_replication
     - /sv/news/poliovirus_replication
-images: ["/highlights/banners/segmentation_highReso.jpeg"]
 announcement: "This data highlight was also <a class='dark-blue' target='_blank' href='https://data.scilifelab.se/highlights/poliovirus_replication/'>published on the SciLifeLab Data Platform</a>, as the work described in this highlight constitutes data-driven life science. The Platform is a hub for data-driven life science in Sweden, containing multiple relevant resources, tools, and services. It includes information on multiple subjects, including infectious diseases, please check out the <a class='dark-blue' target='_blank' href='https://data.scilifelab.se/'>Data Platform</a> for more."
 images: [/highlights/banners/segmentation_highReso.jpeg]
 ---


### PR DESCRIPTION
In `latest` version of `hugo`, the site (html files) generation fails when there are duplicate front matter items. Because of this, some [actions](https://github.com/ScilifelabDataCentre/pathogens-portal/actions/runs/18710359005/job/53357111983) fail.

So in this PR, we remove duplicate front matter variable in offending files.
