### PR TITLE
FREYA-1773:Update footer to remove NIH notice

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -77,11 +77,6 @@
   <div class="row mt-2">
     <div class="col-md small px-5 px-md-2 pt-1">
       {{ if eq $.Site.Language.LanguageName "English" }}
-        <p class="mb-2">
-          This project is supported by the National Institute Of Allergy And Infectious Diseases (NIAID) of the National Institutes of Health (NIH) 
-          under Award Number U24AI183840. The content is solely the responsibility of the authors and does not necessarily represent the official 
-          views of the National Institutes of Health.
-        </p>
         <p class="mb-1">
           The website content is licensed under the <a target="_blank" rel="license" href="https://creativecommons.org/licenses/by/4.0/">
           CC-BY 4.0 International License <i class="bi bi-cc-circle" style="vertical-align:text-top;"></i></a>
@@ -93,7 +88,7 @@
           </a> 
           and it is available on 
           <a target="_blank" href="https://github.com/ScilifelabDataCentre/pathogens-portal{{ with $code_version }}/tree/{{ $code_version }}{{ end }}">
-              Github {{ with $code_version }}<span class="ps-1 text-muted">({{ $code_version }})</span>{{ end }}
+              GitHub {{ with $code_version }}<span class="ps-1 text-muted">({{ $code_version }})</span>{{ end }}
           </a>
         </p>
         <p>


### PR DESCRIPTION
### 📋 Summary
<!-- Briefly describe WHAT and WHY of this PR -->
This PR removes the NIH notice in the footer 
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- Remove NIH notice in footer 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [X] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [X] Jira / Github issue is linked
- [X] Assignee is selected
- [X] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [X] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-1773](https://scilifelab.atlassian.net/browse/FREYA-1773?atlOrigin=eyJpIjoiNjYzZWM0MzRlZWEzNGMzODkxYmNhOTczMTA4MDNiNTciLCJwIjoiaiJ9)
