### PR TITLE
Update hugo to v0.157.0

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # Use alpine Linux, download desired version of HUGO and build html files
-FROM alpine:3.19.1 AS build
-RUN apk add --no-cache wget=1.21.4-r0
-ARG HUGO_VERSION="0.147.3"
+FROM alpine:3.23.3 AS build
+RUN apk add --no-cache wget=1.25.0-r2
+ARG HUGO_VERSION="0.157.0"
 ARG HUGO_ENV_ARG
 WORKDIR /src
 COPY ./ /src

--- a/config.yaml
+++ b/config.yaml
@@ -87,11 +87,6 @@ markup:
     renderer:
       unsafe: true
 
-caches:
-  getjson:
-    dir: :cacheDir/:project
-    maxAge: 10s
-
 taxonomies:
   highlights_topic: highlights_topics
   highlights_voc: highlights_vocs


### PR DESCRIPTION
Hugo latest version `v0.157.0` is released and has many changes to it. So better to use it to avoid unexpected errors in future.