### PR TITLE
Add notices to SEEC pages and change where update date comes from

### DIFF
--- a/content/english/dashboards/covid_quantification/_index.md
+++ b/content/english/dashboards/covid_quantification/_index.md
@@ -11,10 +11,14 @@ aliases:
   - /dashboards/wastewater/covid_quant_slu/
   - /dashboards/wastewater/covid_quantification/
   - /dashboards/wastewater/covid_quantification/covid_quant_slu/
-dashboards_topics: [Wastewater Surveillance, COVID-19, Infectious diseases, Epidemiology]
+dashboards_topics:
+  [Wastewater Surveillance, COVID-19, Infectious diseases, Epidemiology]
 data_status: "updating"
 ---
 
+<div class="alert alert-info">
+Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+</div>
 
 ## Introduction
 
@@ -101,6 +105,7 @@ The freshly collected samples are processed according to standard methodologies.
 Absolute quantification of the copy numbers of the SARS-CoV-2 genome is performed using One-Step RT-qPCR. Until week 31 of 2023 the quantification of the viral genomes was performed using the [SARS-CoV-2 specific N1 assay from the Centers for Disease Control and Prevention (CDC)](https://www.fda.gov/media/134922/download). From week 32 of 2023 quantification is performed using the Flu SC2 Multiplex Assay (CDC). To correct for variations in population size and wastewater flow, the pepper mild mottle virus (PMMoV) is quantified using a modified version of the assay of [Zhang _et al._ (2006)](https://doi.org/10.1371/journal.pbio.0040003). PMMoV is an abundant RNA virus in human faeces and serves as an estimator of human faecal content ([Symonds _et al._, 2019](https://doi.org/10.1371/journal.ppat.1007639)). For more details about the sample processing method, and the evaluation of the use of the PMMoV normalisation method for Swedish wastewater, please refer to the corresponding publication: [Isaksson _et al._ (2022)](https://www.mdpi.com/2076-3298/9/3/39).
 
 The data in the graphs and datafile is presented in three different formats:
+
 - **PMMoV normalised SARS-CoV2 content** represents the ratio of the copy numbers of SARS-CoV2 and PMMoV measured by the SARS-CoV2 assay and PMMoV-assays, respectively, multiplied by 1000. As the SARS-CoV2 assay provides proxies for SARS-CoV2 virus content in the wastewater and PMMoV is a proxy of the faecal content (which is related to the contributing population), the ratio of the two can be considered to be a proxy for the prevalence of SARS-CoV2 infections in the population of the wastewater catchment area.
 - **SARS-CoV2 genome copies concentration** presents the SARS-CoV2 copy number concentration measured in the wastewater. These data is influenced by the setup of the different wastewater collection nsystems and is therefore not suitable for comparison betwwen sites. The virus concentrations in the wastewater are also influenced by the weather events that impact wastewater flow (e.g., heavy rain or snow melt).
 - **SARS-CoV2 genome copies/day/inhabitant** represents the daily virus amount estimated in the wastewater normalized for the number of inhabitants connected to the system. These data allows for comparison of different sites but some delays in the presentation of these data may occur compared to the other.
@@ -112,7 +117,6 @@ Isaksson, F., Lundy, L., Hedström, A., Székely, A. J., Mohamed, N. (2022). Eva
 ## Related data
 
 - SARS-CoV-2 variant analysis from wastewater (data available in the European Nucleotide Archive (ENA) under project number [PRJEB60156](https://www.ebi.ac.uk/ena/browser/view/PRJEB60156)): The group at SLU analysed samples from Uppsala, Örebro, Umeå, and Kalmar (2021-2022).
-
 
 ## Archived data from SLU
 
@@ -126,5 +130,3 @@ Other groups also quantified SARS-CoV-2 in wastewater in Sweden. The groups used
 - [**Gothenburg university (GU):**](/dashboards/covid_quantification/covid_quant_gu/) Quantification of the level of SARS-CoV-2 in wastewater from Gothenburg by the Norder group at GU.
 
 - [**SEEC-KTH node:**](/dashboards/covid_quantification/covid_quant_kth/) Quantification of the levels of SARS-CoV-2 in wastewater from Stockholm and Malmö by the SEEC-KTH node (no longer updated after June 2023, historic data is available).
-
-

--- a/content/english/dashboards/covid_quantification/_index.md
+++ b/content/english/dashboards/covid_quantification/_index.md
@@ -17,7 +17,7 @@ data_status: "updating"
 ---
 
 <div class="alert alert-info">
-Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+To see data updates, please go to the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/sars-cov-2/">SARS-CoV-2 quantification tab</a>, found on the beta-version of the site. Data on this page will no longer be updated.
 </div>
 
 ## Introduction
@@ -35,7 +35,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: <span id="last_modified_uppsala"></span></div>
+<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/sars-cov-2/"> SARS-CoV-2 quantification tab</a>).</div>
 
 <button type="button" class="btn btn-sm btn-outline-secondary mb-2" data-bs-toggle="modal" data-bs-target="#interactiveFeaturesModal">
   How to use the interactive features of the plot

--- a/content/english/dashboards/covid_quantification/_index.md
+++ b/content/english/dashboards/covid_quantification/_index.md
@@ -35,7 +35,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/sars-cov-2/"> SARS-CoV-2 quantification tab</a>).</div>
+<div class="alert alert-info">Last updated: 2026-03-30 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/sars-cov-2/"> SARS-CoV-2 quantification tab</a>).</div>
 
 <button type="button" class="btn btn-sm btn-outline-secondary mb-2" data-bs-toggle="modal" data-bs-target="#interactiveFeaturesModal">
   How to use the interactive features of the plot

--- a/content/english/dashboards/influenza_quantification/_index.md
+++ b/content/english/dashboards/influenza_quantification/_index.md
@@ -30,7 +30,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-a-virus/"> influenza A</a> and <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-b-virus/"> influenza B</a> quantification tabs).</div>
+<div class="alert alert-info">Last updated: 2026-03-30 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-a-virus/"> influenza A</a> and <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-b-virus/"> influenza B</a> quantification tabs).</div>
 
 ### Influenza A
 

--- a/content/english/dashboards/influenza_quantification/_index.md
+++ b/content/english/dashboards/influenza_quantification/_index.md
@@ -14,7 +14,7 @@ data_status: "updating"
 ---
 
 <div class="alert alert-info">
-Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+To see data updates, please go to the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-a-virus/"> influenza A</a> and <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-b-virus/"> influenza B</a> quantification tabs, found on the beta-version of the site. Data on this page will no longer be updated.
 </div>
 
 ## Introduction
@@ -30,7 +30,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: <span id="last_modified_slu_flu"></span></div>
+<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-a-virus/"> influenza A</a> and <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/influenza-b-virus/"> influenza B</a> quantification tabs).</div>
 
 ### Influenza A
 

--- a/content/english/dashboards/influenza_quantification/_index.md
+++ b/content/english/dashboards/influenza_quantification/_index.md
@@ -4,7 +4,7 @@ plotly: true
 banner: /dashboard_thumbs/wastewater_influenza.png
 description: Explore Influenza A and B virus levels in wastewater across Sweden. Weekly data from SLU-SEEC tracks Influenza trends, covering 43% of the Swedish population, and aids in predicting potential outbreaks.
 menu:
- dashboard_menu:
+  dashboard_menu:
     identifier: wastewater_influenza_quantification
     name: "Wastewater: Influenza Quantification (SLU)"
 aliases:
@@ -12,6 +12,10 @@ aliases:
 dashboards_topics: [Wastewater Surveillance, Influenza, Epidemiology]
 data_status: "updating"
 ---
+
+<div class="alert alert-info">
+Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+</div>
 
 ## Introduction
 
@@ -86,6 +90,7 @@ The viral genomic material from the freshly collected samples is extracted by th
 Absolute quantification of the copy numbers of the genome of influenza A and B viruses is performed by One-Step RT-qPCR using the Flu SC2 Multiplex Assay from the Centers for Disease Control and Prevention (CDC). To correct for variations in population size and wastewater flow, pepper mild mottle virus (PMMoV) is quantified using a modified version of the assay of [Zhang et al. (2006)](https://doi.org/10.1371/journal.pbio.0040003). PMMoV is an abundant RNA virus in human faeces and serves as an estimator of human faecal content ([Symonds et al., 2019](https://doi.org/10.1371/journal.ppat.1007639)).
 
 The data in the graphs and datafile is presented in three different formats:
+
 - **PMMoV normalised Influenza content** represents the ratio of the copy numbers of influenza and PMMoV measured by the influenza assay and PMMoV-assays, respectively, multiplied by 1000. As the influenza assay provides proxies for influenza virus content in the wastewater and PMMoV is a proxy of the faecal content (which is related to the contributing population), the ratio of the two can be considered to be a proxy for the prevalence of influenza infections in the population of the wastewater catchment area.
 - **Influenza genome copies concentration** presents the influenza copy number concentration measured in the wastewater. These data is influenced by the setup of the different wastewater collection nsystems and is therefore not suitable for comparison betwwen sites. The virus concentrations in the wastewater are also influenced by the weather events that impact wastewater flow (e.g., heavy rain or snow melt).
 - **Influenza genome copies/day/inhabitant** represents the daily virus amount estimated in the wastewater normalized for the number of inhabitants connected to the system. These data allows for comparison of different sites but some delays in the presentation of these data may occur compared to the other.

--- a/content/english/dashboards/rsv_quantification.md
+++ b/content/english/dashboards/rsv_quantification.md
@@ -28,7 +28,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/rsv/"> RSV quantification tab</a>).</div>
+<div class="alert alert-info">Last updated: 2026-03-30 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/rsv/"> RSV quantification tab</a>).</div>
 
 <div class="d-md-none alert alert-info">
   Rotating your phone may improve graph layout

--- a/content/english/dashboards/rsv_quantification.md
+++ b/content/english/dashboards/rsv_quantification.md
@@ -12,7 +12,7 @@ data_status: "updating"
 ---
 
 <div class="alert alert-info">
-Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+To see data updates, please go to the newn<a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/rsv/"> RSV quantification tab</a>, found on the beta-version of the site. Data on this page will no longer be updated.
 </div>
 
 ## Introduction
@@ -28,7 +28,7 @@ The scores provided in the dataset and depicted in the plot below are preliminar
 
 ## Visualisations
 
-<div class="alert alert-info">Last updated: <span id="last_modified_slu_rsv"></span></div>
+<div class="alert alert-info">Last updated: 2026-03-23 (further updates are available on the new <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/rsv/"> RSV quantification tab</a>).</div>
 
 <div class="d-md-none alert alert-info">
   Rotating your phone may improve graph layout

--- a/content/english/dashboards/rsv_quantification.md
+++ b/content/english/dashboards/rsv_quantification.md
@@ -11,6 +11,10 @@ dashboards_topics: [Wastewater Surveillance, RSV, Epidemiology]
 data_status: "updating"
 ---
 
+<div class="alert alert-info">
+Data will now exclusively be updated on the <a href="https://swedish-pathogens-portal.scilifelab-2-dev.sys.kth.se/dashboards/slu-wastewater/">new version of this dashboard</a> found on the beta-version of the site. Please refer to that dashboard for future updates.
+</div>
+
 ## Introduction
 
 Respiratory Syncytial Virus (RSV) is a negative-sense, single-stranded RNA virus that causes infections of the lungs and respiratory tract. Most people only have mild, cold-like symptoms and recover quickly, but infants and older adults can develop severe RSV and need hospitalization. RSV is one of the major reasons of hospitalization for respiratory illnesses in infants < 1 year old. For more information about symptoms, risks and vaccination against RSV, visit the corresponding site of the [Swedish Public Health Agency](https://www.folkhalsomyndigheten.se/smittskydd-beredskap/smittsamma-sjukdomar/rs-virusinfektion/).
@@ -73,4 +77,3 @@ The data in the graphs and datafile is presented in three different formats:
 **How to cite the method:**
 
 Isaksson, F., Lundy, L., Hedström, A., Székely, A. J., Mohamed, N. (2022). Evaluating the Use of Alternative Normalization Approaches on SARS-CoV-2 Concentrations in Wastewater: Experiences from Two Catchments in Northern Sweden. _Environments_, _9_, 39. <https://doi.org/10.3390/environments9030039>.
-

--- a/content/english/updates/PLP_TDP25_update.md
+++ b/content/english/updates/PLP_TDP25_update.md
@@ -1,5 +1,5 @@
 ---
-title: "New capbilities from the Pandemic Laboratory Preparedness (PLP) program"
+title: "New capabilities from the Pandemic Laboratory Preparedness (PLP) program"
 date: 2026-03-12
 summary: Check out the latest capabilities developed from SciLifeLab's Pandemic Laboratory Preparedness (PLP) program.
 banner: /updates/banners/plp_default2.png

--- a/layouts/shortcodes/ww_dynamic_content.html
+++ b/layouts/shortcodes/ww_dynamic_content.html
@@ -6,7 +6,7 @@
        "type": "dataset"
      },
      {
-       "url": "https://blobserver.dc.scilifelab.se/blob/new_slu_ww_data.csv/info.json",
+       "url": "https://blobserver.dc.scilifelab.se/blob/SLU_wastewater_data.csv/info.json",
        "to_update": ["last_modified_uppsala", "last_modified_slu_flu", "last_modified_slu_rsv"],
        "type": "dataset"
      },

--- a/layouts/shortcodes/ww_dynamic_content.html
+++ b/layouts/shortcodes/ww_dynamic_content.html
@@ -6,7 +6,7 @@
        "type": "dataset"
      },
      {
-       "url": "https://blobserver.dc.scilifelab.se/blob/SLU_wastewater_data.csv/info.json",
+       "url": "https://blobserver.dc.scilifelab.se/blob/new_slu_ww_data.csv/info.json",
        "to_update": ["last_modified_uppsala", "last_modified_slu_flu", "last_modified_slu_rsv"],
        "type": "dataset"
      },


### PR DESCRIPTION
### 📋 Summary
This PR adds notices to the SEEC dashboards on the old version of the portal and changes the data file that the update date is taken from so that the pages don't look stale. 
 
### 🛠️ Changes Made
<!-- One-liners or bullet points -->
- notices on all three dashboard pages 
- Appropriate shortcake updated with new data file. 

### 🔍 Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
 
### ✅ Checklist
- [X] PR title follows the pattern: `FREYA-XXXX: Clear and short description`
- [X] Jira / Github issue is linked
- [X] Assignee is selected
- [X] Code and content adhere to [conventions](https://scilifelab.atlassian.net/wiki/spaces/CDP2/pages/1909424133/Guidelines+for+the+portal+content)
- [X] Automated checks pass
- [X] Reviewer is selected when the PR is marked as ready for review

### 🔗 Jira Issue
<!-- Example: FREYA-914 -->
Closes: [FREYA-2252](https://scilifelab.atlassian.net/browse/FREYA-2252)
